### PR TITLE
added support to image copied from pdf doc.

### DIFF
--- a/pngpaste.m
+++ b/pngpaste.m
@@ -24,16 +24,45 @@ main (int argc, const char **argv)
     NSImage *image = [[NSImage alloc] initWithPasteboard:pasteBoard];
     if (image) {
         NSArray *reps = [image representations];
-        NSData *pngData = [NSBitmapImageRep
-                           representationOfImageRepsInArray:reps
-                                                  usingType:NSPNGFileType
-                                                 properties:nil];
-        NSString *filename =
+		id rep = [reps lastObject];
+		if (![rep isKindOfClass:[NSImageRep class]]) {
+			fprintf(stderr, "No image or pdf data found on the clipboard!!\n");
+			return EXIT_FAILURE;
+		}
+		NSString *filename =
             [[NSString alloc] initWithCString:argv[1]
                                      encoding:NSUTF8StringEncoding];
+		NSData *pngData;
+		NSImageRep *imageRep = (NSImageRep *)rep;
+		if ([rep isKindOfClass:[NSPDFImageRep class]]) {
+			NSPDFImageRep *pdfImageRep = (NSPDFImageRep *)imageRep;
+			CGFloat factor = 1.5;
+			NSRect bounds = NSMakeRect(0, 0,
+									   pdfImageRep.bounds.size.width * factor,
+									   pdfImageRep.bounds.size.height * factor);
+			NSImage *image = [[NSImage alloc] initWithSize:bounds.size];
+			[image lockFocus];
+			[[NSColor whiteColor] set];
+			NSRectFill(bounds);
+			[imageRep drawInRect:bounds];
+			[image unlockFocus];
+
+			NSData *imageData = [image TIFFRepresentation];
+			
+			// NSDictionary *pngProp = [NSDictionary dictionaryWithObject:[NSNumber numberWithFloat:1.0]
+			// 													forKey:NSImageCompressionFactor];
+			pngData = [[NSBitmapImageRep imageRepWithData:imageData]
+						  representationUsingType:NSPNGFileType
+									   properties:nil];
+		} else {
+			pngData = [NSBitmapImageRep
+								  representationOfImageRepsInArray:reps
+														 usingType:NSPNGFileType
+														properties:nil];
+		}
         [pngData writeToFile:filename atomically:YES];
     } else {
-        fprintf(stderr, "No PNG data found on the clipboard!\n");
+        fprintf(stderr, "No image data found on the clipboard!\n");
     }
 
     [image release];


### PR DESCRIPTION
At first, thanks for this nice and neat tool that can help me to save images easily for my text oriented document tool(emacs org-mode). 

This patch enables us to save image that is copied in mac osx 'Preview' opening pdf file.

Thanks.
