### PR TITLE
Output Format Detection by Filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # pngpaste changelog
 
+## latest and greatest
+
+* Output in multiple formats, based on filename.
+
 ## 0.2.1
 
 * If file cannot be written (permission denied etc), it says so

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ Or with Homebrew:
 
     $ pngpaste hooray.png
 
+### Bonus and Disclaimers
+
+Supported input formats are PNG, PDF, GIF, TIF, JPEG.
+
+Supported output formats are PNG, GIF, JPEG, TIFF.
+
+Output formats are determined by the provided filename extension,
+falling back to PNG.
+
+It's unclear if EXIF data in JPEG sources are preserved. There's an
+issue with pasting into JPEG format from a GIF source.
+
 ### Error Handling
 
 Minimal :'(

--- a/pngpaste.h
+++ b/pngpaste.h
@@ -40,4 +40,5 @@ NSData *getPasteboardImageData (NSBitmapImageFileType bitmapImageFileType);
 
 Parameters parseArguments (int argc, char* const argv[]);
 
+
 int main (int argc, char * const argv[]);

--- a/pngpaste.h
+++ b/pngpaste.h
@@ -11,11 +11,11 @@
 #define PDF_SCALE_FACTOR 1.5
 #define STDOUT_FILENAME "-"
 
-typedef enum imageTypes
+typedef enum imageType
 {
     ImageTypeNone = 0,
-    ImageTypePNG,
-    ImageTypePDF
+    ImageTypePDF,
+    ImageTypeBitmap,
 } ImageType;
 
 typedef struct parameters
@@ -32,9 +32,11 @@ void fatal (const char *msg);
 void version ();
 
 ImageType extractImageType (NSImage *image);
-NSData *extractPngData (NSImage *image);
-NSData *extractPngDataFromPng (NSImage *image);
-NSData *extractPngDataFromPdf (NSImage *image);
+NSData *renderImageData (NSImage *image, NSBitmapImageFileType bitmapImageFileType);
+NSData *renderFromBitmap (NSImage *image, NSBitmapImageFileType bitmapImageFileType);
+NSData *renderFromPDF (NSImage *image, NSBitmapImageFileType bitmapImageFileType);
+NSBitmapImageFileType getBitmapImageFileTypeFromFilename (NSString *filename);
+NSData *getPasteboardImageData (NSBitmapImageFileType bitmapImageFileType);
 
 Parameters parseArguments (int argc, char* const argv[]);
 

--- a/pngpaste.m
+++ b/pngpaste.m
@@ -67,7 +67,7 @@ renderFromBitmap (NSImage *image, NSBitmapImageFileType bitmapImageFileType)
 {
     return [NSBitmapImageRep representationOfImageRepsInArray:[image representations]
                                                     usingType:bitmapImageFileType
-                                                   properties:nil];
+                                                   properties:@{}];
 }
 
 NSData *
@@ -91,7 +91,7 @@ renderFromPDF (NSImage *image, NSBitmapImageFileType bitmapImageFileType)
     NSData *genImageData = [genImage TIFFRepresentation];
     return [[NSBitmapImageRep imageRepWithData:genImageData]
                        representationUsingType:bitmapImageFileType
-                                    properties:nil];
+                                    properties:@{}];
 }
 
 /*

--- a/pngpaste.m
+++ b/pngpaste.m
@@ -32,7 +32,7 @@ ImageType
 extractImageType (NSImage *image)
 {
     ImageType imageType = ImageTypeNone;
-    if (image != NULL) {
+    if (image != nil) {
         NSArray *reps = [image representations];
         NSImageRep *rep = [reps lastObject];
         if ([rep isKindOfClass:[NSPDFImageRep class]]) {
@@ -57,7 +57,7 @@ renderImageData (NSImage *image, NSBitmapImageFileType bitmapImageFileType)
         break;
     case ImageTypeNone:
     default:
-        return NULL;
+        return nil;
         break;
     }
 }
@@ -112,7 +112,7 @@ getBitmapImageFileTypeFromFilename (NSString *filename)
         };
     }
     NSBitmapImageFileType bitmapImageFileType = NSBitmapImageFileTypePNG;
-    if (filename != NULL) {
+    if (filename != nil) {
         NSArray *words = [filename componentsSeparatedByString:@"."];
         NSUInteger len = [words count];
         if (len > 1) {
@@ -128,16 +128,16 @@ getBitmapImageFileTypeFromFilename (NSString *filename)
 }
 
 /*
- * Returns NSData from Pasteboard Image if available; otherwise NULL
+ * Returns NSData from Pasteboard Image if available; otherwise nil
  */
 NSData *
 getPasteboardImageData (NSBitmapImageFileType bitmapImageFileType)
 {
     NSPasteboard *pasteBoard = [NSPasteboard generalPasteboard];
     NSImage *image = [[NSImage alloc] initWithPasteboard:pasteBoard];
-    NSData *imageData = NULL;
+    NSData *imageData = nil;
 
-    if (image != NULL) {
+    if (image != nil) {
         imageData = renderImageData(image, bitmapImageFileType);
     }
 
@@ -150,7 +150,7 @@ parseArguments (int argc, char* const argv[])
 {
     Parameters params;
 
-    params.outputFile = NULL;
+    params.outputFile = nil;
     params.wantsVersion = NO;
     params.wantsUsage = NO;
     params.wantsStdout = NO;
@@ -207,7 +207,7 @@ main (int argc, char * const argv[])
     NSData *imageData = getPasteboardImageData(bitmapImageFileType);
     int exitCode;
 
-    if (imageData != NULL) {
+    if (imageData != nil) {
         if (params.wantsStdout) {
             NSFileHandle *stdout =
                 (NSFileHandle *)[NSFileHandle fileHandleWithStandardOutput];

--- a/pngpaste.m
+++ b/pngpaste.m
@@ -222,7 +222,7 @@ main (int argc, char * const argv[])
             }
         }
     } else {
-        fatal("No image data found on the clipboard!");
+        fatal("No image data found on the clipboard, or could not convert!");
         exitCode = EXIT_FAILURE;
     }
 

--- a/pngpaste.m
+++ b/pngpaste.m
@@ -154,17 +154,17 @@ main (int argc, char * const argv[])
     NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
     NSPasteboard *pasteBoard = [NSPasteboard generalPasteboard];
     NSImage *image = [[NSImage alloc] initWithPasteboard:pasteBoard];
-    NSData *pngData;
+    NSData *imageData;
     int exitCode;
 
-    if (image && ((pngData = extractPngData(image)) != NULL)) {
+    if (image && ((imageData = extractPngData(image)) != NULL)) {
         if (params.wantsStdout) {
             NSFileHandle *stdout =
                 (NSFileHandle *)[NSFileHandle fileHandleWithStandardOutput];
-            [stdout writeData:pngData];
+            [stdout writeData:imageData];
             exitCode = EXIT_SUCCESS;
         } else {
-            if ([pngData writeToFile:params.outputFile atomically:YES]) {
+            if ([imageData writeToFile:params.outputFile atomically:YES]) {
                 exitCode = EXIT_SUCCESS;
             } else {
                 fatal("Could not write to file!");

--- a/pngpaste.m
+++ b/pngpaste.m
@@ -100,6 +100,17 @@ renderFromPDF (NSImage *image, NSBitmapImageFileType bitmapImageFileType)
 NSBitmapImageFileType
 getBitmapImageFileTypeFromFilename (NSString *filename)
 {
+    static NSDictionary *lookup;
+    if (lookup == nil) {
+        lookup = @{
+            @"gif": [NSNumber numberWithInt:NSBitmapImageFileTypeGIF],
+            @"jpeg": [NSNumber numberWithInt:NSBitmapImageFileTypeJPEG],
+            @"jpg": [NSNumber numberWithInt:NSBitmapImageFileTypeJPEG],
+            @"png": [NSNumber numberWithInt:NSBitmapImageFileTypePNG],
+            @"tif": [NSNumber numberWithInt:NSBitmapImageFileTypeTIFF],
+            @"tiff": [NSNumber numberWithInt:NSBitmapImageFileTypeTIFF],
+        };
+    }
     NSBitmapImageFileType bitmapImageFileType = NSBitmapImageFileTypePNG;
     if (filename != NULL) {
         NSArray *words = [filename componentsSeparatedByString:@"."];
@@ -107,16 +118,9 @@ getBitmapImageFileTypeFromFilename (NSString *filename)
         if (len > 1) {
             NSString *extension = (NSString *)[words objectAtIndex:(len - 1)];
             NSString *lowercaseExtension = [extension lowercaseString];
-            if ([lowercaseExtension isEqualToString:@"png"]) {
-                bitmapImageFileType = NSBitmapImageFileTypePNG;
-            } else if ([lowercaseExtension isEqualToString:@"jpg"]) {
-                bitmapImageFileType = NSBitmapImageFileTypeJPEG;
-            } else if ([lowercaseExtension isEqualToString:@"jpeg"]) {
-                bitmapImageFileType = NSBitmapImageFileTypeJPEG;
-            } else if ([lowercaseExtension isEqualToString:@"tif"]) {
-                bitmapImageFileType = NSBitmapImageFileTypeTIFF;
-            } else if ([lowercaseExtension isEqualToString:@"tiff"]) {
-                bitmapImageFileType = NSBitmapImageFileTypeTIFF;
+            NSNumber *value = lookup[lowercaseExtension];
+            if (value != nil) {
+                bitmapImageFileType = [value unsignedIntegerValue];
             }
         }
     }

--- a/pngpaste.m
+++ b/pngpaste.m
@@ -136,6 +136,24 @@ parseArguments (int argc, char* const argv[])
     return params;
 }
 
+/*
+ * Returns NSData from Pasteboard Image if available; otherwise NULL
+ */
+NSData *
+getPasteboardImageData ()
+{
+    NSPasteboard *pasteBoard = [NSPasteboard generalPasteboard];
+    NSImage *image = [[NSImage alloc] initWithPasteboard:pasteBoard];
+    NSData *imageData = NULL;
+
+    [pasteBoard release];
+    if (image != NULL) {
+        imageData = extractPngData(image);
+        [image release];
+    }
+    return imageData;
+}
+
 int
 main (int argc, char * const argv[])
 {
@@ -151,13 +169,10 @@ main (int argc, char * const argv[])
         return EXIT_SUCCESS;
     }
 
-    NSAutoreleasePool *pool = [[NSAutoreleasePool alloc] init];
-    NSPasteboard *pasteBoard = [NSPasteboard generalPasteboard];
-    NSImage *image = [[NSImage alloc] initWithPasteboard:pasteBoard];
-    NSData *imageData;
+    NSData *imageData = getPasteboardImageData();
     int exitCode;
 
-    if (image && ((imageData = extractPngData(image)) != NULL)) {
+    if (imageData != NULL) {
         if (params.wantsStdout) {
             NSFileHandle *stdout =
                 (NSFileHandle *)[NSFileHandle fileHandleWithStandardOutput];
@@ -175,10 +190,6 @@ main (int argc, char * const argv[])
         fatal("No image data found on the clipboard!");
         exitCode = EXIT_FAILURE;
     }
-
-    [image release];
-    [pasteBoard release];
-    [pool release];
 
     return exitCode;
 }


### PR DESCRIPTION
Reference issue: https://github.com/jcsalterego/pngpaste/issues/8

This uses the output filename to determine the desired output format, always falling back to PNG if there is no known extension or if standard out is specified. There's also some cleanup.